### PR TITLE
fix: invalid encoding for hash

### DIFF
--- a/.changeset/thin-waves-wish.md
+++ b/.changeset/thin-waves-wish.md
@@ -1,0 +1,5 @@
+---
+"astro-typed-links": minor
+---
+
+Encode hash and searchParams by encodeURIComponent to make it special characters aware and handle edge cases

--- a/.changeset/thin-waves-wish.md
+++ b/.changeset/thin-waves-wish.md
@@ -2,4 +2,4 @@
 "astro-typed-links": minor
 ---
 
-Encode hash and searchParams by encodeURIComponent to make it special characters aware and handle edge cases
+Improve handling of special characters and spaces in hash values by using `encodeURIComponent`.

--- a/.changeset/thin-waves-wish.md
+++ b/.changeset/thin-waves-wish.md
@@ -1,5 +1,5 @@
 ---
-"astro-typed-links": minor
+"astro-typed-links": patch
 ---
 
-Improve handling of special characters and spaces in hash values by using `encodeURIComponent`.
+Fixes a case where a URL would not be valid because `hash` was not encoded

--- a/packages/astro-typed-links/src/link.ts
+++ b/packages/astro-typed-links/src/link.ts
@@ -43,17 +43,16 @@ export const link = <TPath extends keyof AstroTypedLinks>(
 		if (opts.searchParams instanceof URLSearchParams) {
 			newPath += `?${opts.searchParams.toString()}`;
 		} else {
-			// We need custom handling to avoid encoding
 			const entries = Object.entries(opts.searchParams);
 			for (let i = 0; i < entries.length; i++) {
 				// biome-ignore lint/style/noNonNullAssertion: we know the element exists for this index
 				const [key, value] = entries[i]!;
-				newPath += `${i === 0 ? "?" : "&"}${key}=${value}`;
+				newPath += `${i === 0 ? "?" : "&"}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
 			}
 		}
 	}
 	if (opts?.hash) {
-		newPath += `#${opts.hash}`;
+		newPath += `#${encodeURIComponent(opts.hash)}`;
 	}
 	return newPath;
 };

--- a/packages/astro-typed-links/src/link.ts
+++ b/packages/astro-typed-links/src/link.ts
@@ -43,6 +43,7 @@ export const link = <TPath extends keyof AstroTypedLinks>(
 		if (opts.searchParams instanceof URLSearchParams) {
 			newPath += `?${opts.searchParams.toString()}`;
 		} else {
+			// We need custom handling to avoid encoding
 			const entries = Object.entries(opts.searchParams);
 			for (let i = 0; i < entries.length; i++) {
 				// biome-ignore lint/style/noNonNullAssertion: we know the element exists for this index

--- a/packages/astro-typed-links/src/link.ts
+++ b/packages/astro-typed-links/src/link.ts
@@ -47,7 +47,7 @@ export const link = <TPath extends keyof AstroTypedLinks>(
 			for (let i = 0; i < entries.length; i++) {
 				// biome-ignore lint/style/noNonNullAssertion: we know the element exists for this index
 				const [key, value] = entries[i]!;
-				newPath += `${i === 0 ? "?" : "&"}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+				newPath += `${i === 0 ? "?" : "&"}${key}=${value}`;
 			}
 		}
 	}


### PR DESCRIPTION
<strike>
1. removed the misleading comment about "avoiding encoding", added encodeURIComponent() for both keys and values in the plain object branch. This ensures URLs are properly encoded when values contain special characters like `&, =, spaces, etc`.

```shell
// Before: link("/", { searchParams: { foo: "bar&baz=test" } })
// Result: "/?foo=bar&baz=test" (invalid - creates extra param)
 
// After: link("/", { searchParams: { foo: "bar&baz=test" } })
// Result: "/?foo=bar%26baz%3Dtest" (valid URL)
```
</strike>

2. hash value should be encoded to handle special characters properly

```shell
before:
link("/", { hash: "hello world" })
// Result: "/#hello world" (invalid - spaces not allowed in URLs)

after:
link("/", { hash: "hello world" })
// Result: "/#hello%20world" (valid URL)
```