### PR TITLE
perf: optimize the newPath regex, replace inefficiency by using a single regex

### DIFF
--- a/.changeset/honest-brooms-obey.md
+++ b/.changeset/honest-brooms-obey.md
@@ -1,0 +1,5 @@
+---
+"astro-typed-links": patch
+---
+
+Performance optimization for newPath regex, use single regex replace

--- a/.changeset/honest-brooms-obey.md
+++ b/.changeset/honest-brooms-obey.md
@@ -2,4 +2,4 @@
 "astro-typed-links": patch
 ---
 
-Performance optimization for newPath regex, use single regex replace
+Improves performance when linking to routes with dynamic parameters

--- a/packages/astro-typed-links/package.json
+++ b/packages/astro-typed-links/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "astro-typed-links",
-	"version": "1.1.5",
+	"version": "1.2.1",
 	"description": "An Astro integration to automatically get typed links to your pages.",
 	"type": "module",
 	"sideEffects": false,

--- a/packages/astro-typed-links/package.json
+++ b/packages/astro-typed-links/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "astro-typed-links",
-	"version": "1.2.1",
+	"version": "1.1.5",
 	"description": "An Astro integration to automatically get typed links to your pages.",
 	"type": "module",
 	"sideEffects": false,

--- a/packages/astro-typed-links/src/link.ts
+++ b/packages/astro-typed-links/src/link.ts
@@ -31,9 +31,10 @@ export const link = <TPath extends keyof AstroTypedLinks>(
 		for (const [key, value] of Object.entries(
 			opts.params as Record<string, string | undefined>,
 		)) {
-			newPath = newPath
-				.replace(`[${key}]`, value ?? "")
-				.replace(`[...${key}]`, value ?? "");
+			newPath = newPath.replace(
+				new RegExp(`\\[\\.\\.\\.${key}\\]|\\[${key}\\]`, "g"),
+				value ?? "",
+			);
 		}
 		// When using spread parameters with a trailing slash, it results in invalid //
 		// We clean that up


### PR DESCRIPTION
## Description

This change optimize the regex replace inefficiency, as using a single regex pattern that handles both regular and spread parameters.

I've combined two separate .replace() calls into a single regex.
As pattern `\[\.\.\.[key]\]|\[key\]` matches both spread parameters `[...key]` and regular parameters `[key]`. Added `g` flag to replace all occurrences in one pass

Why it's worth to do it? more efficient flow - one regex compilation and one string traversal instead of two. 

## Testing

tested it on playground, it andles both [slug] and [...rest] patterns correctly